### PR TITLE
Remove ciacci's homepage field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "homepage": "http://gerrymapper.org/",
   "version": "0.1.0",
   "private": true,
-  "homepage": "http://ciacci1234.github.io/visualization",
   "dependencies": {
     "bulma": "^0.4.0",
     "dotenv": "^2.0.0",


### PR DESCRIPTION
If the homepage is set to http://ciacci1234.github.io/visualization, the asset paths will be incorrect in the build.