### PR TITLE
Feature/web/top nav fix

### DIFF
--- a/src/components/TimeLine.js
+++ b/src/components/TimeLine.js
@@ -23,7 +23,7 @@ class TimeLine extends Component {
     })
     return (
       <div className='timeLine'>
-        <ul>
+        <ul className='timeLineUL'>
           { years }
         </ul>
       </div>

--- a/src/sass/AppHeader.sass
+++ b/src/sass/AppHeader.sass
@@ -69,9 +69,10 @@
 @media (min-width: 0px) and (max-width: 768px)
   .gm-navA, .gm-navB, .gm-navC
       width: 90px
-      font-size: 8px !important
+      font-size: 7px !important
       font-weight: bold
-      padding-left: 7px
+      padding: 3px
+      overflow-x: hidden
 
   .gm-rightHorn
       border-radius: 0px 0px 0px 0px

--- a/src/sass/AppHeader.sass
+++ b/src/sass/AppHeader.sass
@@ -72,7 +72,6 @@
       font-size: 7px !important
       font-weight: bold
       padding: 3px
-      overflow-x: hidden
 
   .gm-rightHorn
       border-radius: 0px 0px 0px 0px

--- a/src/sass/TimeLine.sass
+++ b/src/sass/TimeLine.sass
@@ -5,6 +5,9 @@
   border-radius: 5px
   height: 4vh
 
+.timeLineUL li
+  padding: 8px!important
+
 ul
   list-style: none
   display: inline


### PR DESCRIPTION
When I bring up gerrmapper.org on my phone, the fonts of the top nav are still goofed up.  This is strange as it works fine locally and when its run in mobile emulators.  I brought down the font-size and the padding. Hopefully this fixs it, otherwise we can add a overflow-x hidden to the containing divs.  