### PR TITLE
Add tests for Redux actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "private": true,
   "dependencies": {
     "bulma": "^0.4.0",
-    "dotenv": "^2.0.0",
     "immutable": "^3.8.1",
     "leaflet": "^1.0.3",
+    "prop-types": "^15.5.9",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-leaflet": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-jsx-a11y": "4.0.0",
     "eslint-plugin-react": "^6.10.3",
     "extract-text-webpack-plugin": "1.0.1",
+    "fetch-mock": "^5.12.0",
     "file-loader": "0.10.0",
     "fs-extra": "0.30.0",
     "gh-pages": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "react-leaflet": "^1.1.4",
     "react-redux": "^5.0.3",
     "react-router": "^4.0.0",
-    "redux": "^3.6.0"
+    "redux": "^3.6.0",
+    "redux-mock-store": "^1.2.3",
+    "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
     "autoprefixer": "6.7.2",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "react-leaflet": "^1.1.4",
     "react-redux": "^5.0.3",
     "react-router": "^4.0.0",
-    "redux": "^3.6.0",
-    "redux-mock-store": "^1.2.3",
-    "redux-thunk": "^2.2.0"
+    "redux": "^3.6.0"
   },
   "devDependencies": {
     "autoprefixer": "6.7.2",
@@ -54,6 +52,8 @@
     "postcss-loader": "1.2.2",
     "promise": "7.1.1",
     "react-dev-utils": "^0.5.2",
+    "redux-mock-store": "^1.2.3",
+    "redux-thunk": "^2.2.0",
     "sass-loader": "^3.2.3",
     "standard": "^10.0.0",
     "style-loader": "0.13.1",

--- a/src/actions/appActions.js
+++ b/src/actions/appActions.js
@@ -36,7 +36,8 @@ export function convertBranch (branch) {
  * onLoad functions checks on the availability of the META-Data
  */
 export function onLoad () {
-  pullMetaData()
+  return (dispatch) =>
+    dispatch(pullMetaData())
 }
 
 /**

--- a/src/actions/appActions.js
+++ b/src/actions/appActions.js
@@ -1,7 +1,6 @@
 import ACTIONS, { uri } from './index'
 import { Map } from 'immutable'
 import { fetchGeoJson, fetchStatsJson } from './mapActions'
-import store from '../configureStore'
 
 /**
  * Simple function to change the year
@@ -46,19 +45,18 @@ export function onLoad () {
 export function pullMetaData () {
   return (dispatch) =>
     window.fetch(uri + 'metaData.json')
-      .then(rsp => {
-        rsp.json().then(json => {
-          const geoFiles = Map(json.geoFiles)
-          const { statsFiles } = json
-          store.dispatch({
-            type: ACTIONS.META_DATA,
-            geoFiles,
-            statsFiles,
-            branch: Object.keys(geoFiles)[0]
-          })
-          fetchGeoJson()
-          fetchStatsJson()
+      .then(rsp => rsp.json())
+      .then(json => {
+        const geoFiles = Map(json.geoFiles)
+        const { statsFiles } = json
+        dispatch({
+          type: ACTIONS.META_DATA,
+          geoFiles,
+          statsFiles,
+          branch: Object.keys(json.geoFiles)[0]
         })
+        fetchGeoJson()
+        fetchStatsJson()
       })
       .catch(() => console.error('Failed to fetch metadata!'))
 }

--- a/src/actions/appActions.js
+++ b/src/actions/appActions.js
@@ -8,10 +8,10 @@ import store from '../configureStore'
  * @param {String} year
  */
 export function changeYear (year) {
-  return () => {
-    store.dispatch({ type: ACTIONS.CHANGE_YEAR, year })
+  return (dispatch) => {
     console.log('Year change')
-    fetchGeoJson()
+    dispatch({ type: ACTIONS.CHANGE_YEAR, year })
+    return fetchGeoJson()
   }
 }
 
@@ -37,34 +37,28 @@ export function convertBranch (branch) {
  * onLoad functions checks on the availability of the META-Data
  */
 export function onLoad () {
-  const { mapDataReducer } = store.getState()
-  // REVIEW: Potentially unnecessary check
-  if (mapDataReducer.geoFiles.size < 1) {
-    pullMetaData()
-    return
-  }
-  fetchGeoJson()
+  pullMetaData()
 }
 
 /**
  * pullMetaData triggers an ajax action and loads necessary data if needed
  */
 export function pullMetaData () {
-  const { META_DATA } = ACTIONS
-  window.fetch(uri + 'metaData.json')
-        .then(rsp => {
-          rsp.json().then(json => {
-            const geoFiles = Map(json.geoFiles)
-            const { statsFiles } = json
-            store.dispatch({
-              type: META_DATA,
-              geoFiles,
-              statsFiles,
-              branch: Object.keys(geoFiles)[0]
-            })
-            fetchGeoJson()
-            fetchStatsJson()
+  return (dispatch) =>
+    window.fetch(uri + 'metaData.json')
+      .then(rsp => {
+        rsp.json().then(json => {
+          const geoFiles = Map(json.geoFiles)
+          const { statsFiles } = json
+          store.dispatch({
+            type: ACTIONS.META_DATA,
+            geoFiles,
+            statsFiles,
+            branch: Object.keys(geoFiles)[0]
           })
+          fetchGeoJson()
+          fetchStatsJson()
         })
-        .catch(e => console.error(e))
+      })
+      .catch(() => console.error('Failed to fetch metadata!'))
 }

--- a/src/actions/appActions.js
+++ b/src/actions/appActions.js
@@ -1,6 +1,6 @@
 import ACTIONS, { uri } from './index'
 import { Map } from 'immutable'
-import { fetchGeoJson, fetchStatsJson } from './mapActions'
+import { fetchGeoJson, switchBranch } from './mapActions'
 
 /**
  * Simple function to change the year
@@ -10,7 +10,7 @@ export function changeYear (year) {
   return (dispatch) => {
     console.log('Year change')
     dispatch({ type: ACTIONS.CHANGE_YEAR, year })
-    return fetchGeoJson()
+    return dispatch(fetchGeoJson())
   }
 }
 
@@ -36,8 +36,7 @@ export function convertBranch (branch) {
  * onLoad functions checks on the availability of the META-Data
  */
 export function onLoad () {
-  return (dispatch) =>
-    dispatch(pullMetaData())
+  return (dispatch) => dispatch(pullMetaData())
 }
 
 /**
@@ -53,11 +52,11 @@ export function pullMetaData () {
         dispatch({
           type: ACTIONS.META_DATA,
           geoFiles,
-          statsFiles,
-          branch: Object.keys(json.geoFiles)[0]
+          statsFiles
         })
-        fetchGeoJson()
-        fetchStatsJson()
+
+        const branch = Object.keys(json.geoFiles)[0]
+        dispatch(switchBranch(branch))
       })
       .catch(() => console.error('Failed to fetch metadata!'))
 }

--- a/src/actions/geoCodeAction.js
+++ b/src/actions/geoCodeAction.js
@@ -1,6 +1,5 @@
 import tokens from './tokens'
 import ACTION_EVENTS from './index'
-import store from '../configureStore'
 
 /**
  * geoCodeAddress serves to convert an address string to a url
@@ -13,16 +12,15 @@ export function geoCodeAddress (addr) {
   const uriAddr = window.encodeURIComponent(addr)
   const uri = 'https://maps.googleapis.com/maps/api/geocode/json?address=' +
               uriAddr + '&key=' + googleAPI
-  window.fetch(uri)
-        .then(response => {
-          response.json().then(json => {
-            if (json.error_message === undefined) {
-              const latLng = json.results.map(r => {
-                return Object.assign({}, r.geometry.location)
-              })
-              store.dispatch({ type: GEO_CODE_ADDR, addr: latLng })
-            } else console.error('API Key error')
-          })
-        })
-        .catch(err => console.log(err))
+
+  return dispatch =>
+    window.fetch(uri)
+      .then(response => response.json())
+      .then(json => {
+        if (json.error_message === undefined) {
+          const latLng = json.results.map(r => r.geometry.location)
+          dispatch({ type: GEO_CODE_ADDR, addr: latLng })
+        } else console.error('API Key error')
+      })
+      .catch(err => console.log(err))
 }

--- a/src/actions/mapActions.js
+++ b/src/actions/mapActions.js
@@ -50,7 +50,7 @@ export function fetchGeoJson () {
           })
         })
         // TODO: FINISH ERROR HANDLER
-        .catch(err => console.log(err))
+        .catch(() => console.log('Failed to fetch GEOJSON!'))
 }
 
 /**

--- a/src/actions/mapActions.js
+++ b/src/actions/mapActions.js
@@ -1,5 +1,4 @@
 import ACTION_EVENTS, { uri } from './index'
-import store from '../configureStore'
 
 /**
  * switchBranch changes the active branch (office) and triggers a fetchGeoJson
@@ -75,7 +74,7 @@ export function fetchStatsJson () {
 
     return window.fetch(fileUri).then(response =>
       response.json().then(json => {
-        store.dispatch({
+        dispatch({
           type: ACTION_EVENTS.STATS_LOADED,
           stats: json
         })

--- a/src/actions/tokens.js
+++ b/src/actions/tokens.js
@@ -6,6 +6,6 @@
  * Current API List
  * google: https://developers.google.com/maps/documentation/geocoding/start
  */
-const tokens = { googleAPI: process.env.REACT_APP_GERRYMAPPER.replace(/[“”]/g, '') }
+const tokens = { googleAPI: process.env.REACT_APP_GERRYMAPPER }
 
 export default tokens

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,12 +1,14 @@
 import React from 'react'
+import { connect } from 'react-redux'
+
 import MapLayer from './MapLayer'
 import AppHeader from './AppHeader'
 import BottomNav from './BottomNav'
 import * as Actions from '../actions/appActions'
 import '../sass/App.sass'
 
-const App = () => {
-  Actions.onLoad()
+const App = connect()(({ dispatch }) => {
+  dispatch(Actions.onLoad())
   return (
     <div className='AppHolder'>
       <div className='App'>
@@ -22,6 +24,6 @@ const App = () => {
 
     </div>
   )
-}
+})
 
 export default App

--- a/src/components/AppHeader.js
+++ b/src/components/AppHeader.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react'
-import SearchBar from './SearchBar'
+import { PropTypes } from 'prop-types'
 import { connect } from 'react-redux'
+import { Map } from 'immutable'
+
+import SearchBar from './SearchBar'
 import * as Actions from '../actions/mapActions'
 import { convertBranch } from '../actions/appActions'
 
@@ -19,15 +22,25 @@ const BranchTab = ({ branch, active }) => {
   )
 }
 
-@connect(state => {
-  return {
+BranchTab.propTypes = {
+  branch: PropTypes.string.isRequired,
+  active: PropTypes.bool.isRequired
+}
+
+@connect(state => (
+  {
     // All the layers that could be processed
     layers: state.mapDataReducer.geoFiles,
     // The current Layer meta-data
     currentBranch: state.mapControllerReducer.branch
   }
-})
+))
 class AppHeader extends Component {
+  static propTypes = {
+    layers: PropTypes.instanceOf(Map).isRequired,
+    currentBranch: PropTypes.string.isRequired
+  }
+
   branchTabs () {
     return this.props.layers.entrySeq().map(([branch, _years]) =>
       <BranchTab
@@ -37,6 +50,7 @@ class AppHeader extends Component {
       />
     )
   }
+
   render () {
     return (
       <div className='App-header'>

--- a/src/components/AppHeader.js
+++ b/src/components/AppHeader.js
@@ -7,7 +7,11 @@ import SearchBar from './SearchBar'
 import * as Actions from '../actions/mapActions'
 import { convertBranch } from '../actions/appActions'
 
-const BranchTab = ({ branch, active }) => {
+const BranchTab = connect(null, (dispatch, { branch }) => ({
+  onClick: () => {
+    dispatch(Actions.switchBranch(branch))
+  }
+}))(({ branch, active, onClick }) => {
   const style = () => {
     const base = 'nav-item '
     if (active) return base + ' active'
@@ -16,11 +20,11 @@ const BranchTab = ({ branch, active }) => {
   }
 
   return (
-    <a onClick={Actions.switchBranch(branch)} className={style()} >
+    <a onClick={onClick} className={style()} >
       <span>{convertBranch(branch)}</span>
     </a>
   )
-}
+})
 
 BranchTab.propTypes = {
   branch: PropTypes.string.isRequired,

--- a/src/components/MapLayer.js
+++ b/src/components/MapLayer.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Map, Marker, TileLayer } from 'react-leaflet'
 import GeoJsonUpdatable from './GeoJsonUpdatable'
@@ -17,12 +18,10 @@ const zoomLevel = 7
  * @param {ReactProps} props - containing lat and long
  */
 const AddressMarker = props => {
-  if (props === null) return null
-  const markers = props.map((e, i) => {
-    const position = [e.lat, e.lng]
-    return <Marker key={i} position={position} />
-  })
-  return markers
+  if (!props) return null
+
+  const position = [props.lat, props.lng]
+  return <Marker position={position} />
 }
 
 const getColorCompactness = (c) =>
@@ -57,22 +56,29 @@ const setDistrictStyle = (feature, layer) => {
  * so leaflet can be updated.
  * https://facebook.github.io/react/docs/refs-and-the-dom.html
  */
-@connect(props => {
-  const { addr, data } = props.mapDataReducer
-  return { addr, data }
+@connect(state => {
+  const { coordinates, data } = state.mapDataReducer
+  return { coordinates, data }
 })
 class MapLayer extends Component {
+  static propTypes = {
+    coordinates: PropTypes.shape({
+      lat: PropTypes.number,
+      lng: PropTypes.number
+    })
+  }
+
   componentWillMount () {
     fetchGeoJson()
   }
 
-  componentDidUpdate (prevProps, prevState) {
+  componentDidUpdate () {
     this.zoomTo()
   }
 
   zoomTo () {
-    if (this.props.addr === null) return
-    const { lat, lng } = this.props.addr[0]
+    if (!this.props.coordinates) return
+    const { lat, lng } = this.props.coordinates
     const latLng = L.latLng([lat, lng])
     this.leaflet.leafletElement.setView(latLng, 14)
   }
@@ -96,7 +102,7 @@ class MapLayer extends Component {
                 attribution={stamenTonerAttr}
                 url={stamenTonerTiles} />
               { geo() }
-              { AddressMarker(this.props.addr) }
+              { AddressMarker(this.props.coordinates) }
             </Map>
           </div>
         </div>

--- a/src/components/MapLayer.js
+++ b/src/components/MapLayer.js
@@ -42,7 +42,7 @@ const setDistrictStyle = (dispatch) => (feature, layer) => {
     fillOpacity: 0.8
   })
   layer.on({
-    click: () => setCurrentDistrict(feature)
+    click: () => dispatch(setCurrentDistrict(feature))
   })
 }
 

--- a/src/components/MapLayer.js
+++ b/src/components/MapLayer.js
@@ -33,7 +33,7 @@ const getColorCompactness = (c) =>
     : c > 0.05 ? '#e31a1c'
     : '#b10026'
 
-const setDistrictStyle = (feature, layer) => {
+const setDistrictStyle = (dispatch) => (feature, layer) => {
   layer.setStyle({
     fillColor: getColorCompactness(feature.properties.Compactness),
     weight: 1,
@@ -69,7 +69,7 @@ class MapLayer extends Component {
   }
 
   componentWillMount () {
-    fetchGeoJson()
+    this.props.dispatch(fetchGeoJson())
   }
 
   componentDidUpdate () {
@@ -87,7 +87,7 @@ class MapLayer extends Component {
     const geo = () => {
       // TODO: refactor in a more efficient manner
       if (Object.keys(this.props.data).length >= 1) {
-        return <GeoJsonUpdatable data={this.props.data} onEachFeature={setDistrictStyle} />
+        return <GeoJsonUpdatable data={this.props.data} onEachFeature={setDistrictStyle(this.props.dispatch)} />
       }
       return null
     }

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -4,10 +4,14 @@ import * as Actions from '../actions/geoCodeAction'
 class SearchBar extends Component {
   constructor () {
     super()
-    this.state = { addr: '1401 John F Kennedy Blvd, Philadelphia, PA 19107' }
+    this.state = { addr: '' }
+
+    // Bind event listeners to the class
+    this.submit = this.submit.bind(this)
+    this.changeVal = this.changeVal.bind(this)
   }
   changeVal (e) {
-    this.setState({addr: e.target.value})
+    this.setState({ addr: e.target.value })
   }
   submit (e) {
     e.preventDefault()
@@ -24,11 +28,11 @@ class SearchBar extends Component {
             <div className='leftNav-innerDiv-middle' />
           </div>
           <div className='column is-5'>
-            <form onSubmit={this.submit.bind(this)} >
+            <form onSubmit={this.submit} >
               <div className='gm-rightHorn'>
                 <input className='gm-form-control'
                   type='text'
-                  onChange={this.changeVal.bind(this)}
+                  onChange={this.changeVal}
                   defaultValue={this.state.addr} />
               </div>
             </form>

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react'
+import { connect } from 'react-redux'
+
 import * as Actions from '../actions/geoCodeAction'
 
+@connect()
 class SearchBar extends Component {
   constructor () {
     super()
@@ -15,7 +18,7 @@ class SearchBar extends Component {
   }
   submit (e) {
     e.preventDefault()
-    Actions.geoCodeAddress(this.state.addr)
+    this.props.dispatch(Actions.geoCodeAddress(this.state.addr))
   }
   render () {
     return (

--- a/src/components/StatsPanel.js
+++ b/src/components/StatsPanel.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 /**
@@ -17,9 +18,16 @@ import { connect } from 'react-redux'
   return { activeDistrict, stats }
 })
 class StatsPanel extends Component {
+  static propTypes = {
+    stats: PropTypes.shape({
+      Candidates: PropTypes.array.isRequired,
+      District: PropTypes.string
+    }),
+    districtCompactness: PropTypes.number
+  }
+
   districtStats () {
     if (this.props.stats) {
-      const district = this.props.activeDistrict
       const { stats } = this.props
       return (
         <div className='statsPanel-ResultsDiv'>
@@ -28,7 +36,7 @@ class StatsPanel extends Component {
 
             <dl>
               <dt><span className='spanUnderline'>Compactness</span></dt>
-              <dd><span className='spanItalics'>{district.properties.Compactness}</span></dd>
+              <dd><span className='spanItalics'>{this.props.districtCompactness}</span></dd>
             </dl>
 
             <div className='resultSpacer' />
@@ -48,11 +56,11 @@ class StatsPanel extends Component {
             </div>
           </div></div>
       )
-    } else {
-      return (
-        <span>Select a district to see more information about that district.</span>
-      )
     }
+
+    return (
+      <span>Select a district to see more information about that district.</span>
+    )
   }
 
   render () {

--- a/src/components/TimeLine.js
+++ b/src/components/TimeLine.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Map } from 'immutable'
 
@@ -19,12 +20,15 @@ const yearLi = prop => {
   return { geoFiles: geoFiles }
 })
 class TimeLine extends Component {
+  static propTypes = {
+    geoFiles: PropTypes.instanceOf(Map).isRequired
+  }
+
   render () {
     const years = this.props.geoFiles.entrySeq()
       .sort((fileA, fileB) => fileB[0] - fileA[0])
-      .map(([ year, file ]) => {
-        return yearLi({ key: file, year: year })
-      })
+      .map(([ year, file ]) => yearLi({ key: file, year })
+      )
 
     return (
       <div className='timeLine'>

--- a/src/components/TimeLine.js
+++ b/src/components/TimeLine.js
@@ -5,14 +5,14 @@ import { Map } from 'immutable'
 
 import { changeYear } from '../actions/appActions'
 
-const yearLi = prop => {
-  const { key, year } = prop
+const Year = connect()(({year, dispatch}) => {
   return (
-    <li key={key} onClick={changeYear(year)} >
+    <li onClick={() => dispatch(changeYear(year))} >
       { year }
     </li>
   )
 }
+)
 
 @connect(state => {
   const { mapDataReducer, mapControllerReducer } = state
@@ -27,7 +27,7 @@ class TimeLine extends Component {
   render () {
     const years = this.props.geoFiles.entrySeq()
       .sort((fileA, fileB) => fileB[0] - fileA[0])
-      .map(([ year, file ]) => yearLi({ key: file, year })
+      .map(([ year, file ]) => (<Year key={file} year={year} />)
       )
 
     return (

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -36,7 +36,7 @@ const defaultState = {
 /**
  * Data Store for the application
  */
-const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
 const store = createStore(
   rootReducer,
   defaultState,

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -1,6 +1,8 @@
-import { createStore } from 'redux'
-import rootReducer from './reducers/index'
+import { compose, createStore, applyMiddleware } from 'redux'
+import thunk from 'redux-thunk'
 import { Map, OrderedSet } from 'immutable'
+
+import rootReducer from './reducers/index'
 
 /* State provided on load */
 const defaultState = {
@@ -34,8 +36,11 @@ const defaultState = {
 /**
  * Data Store for the application
  */
-const store = createStore(rootReducer,
-                          defaultState,
-                          window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__())
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const store = createStore(
+  rootReducer,
+  defaultState,
+  composeEnhancers(applyMiddleware(thunk))
+)
 
 export default store

--- a/src/reducers/mapDataReducer.js
+++ b/src/reducers/mapDataReducer.js
@@ -17,8 +17,8 @@ export function mapDataReducer (state = {}, action) {
       const { data } = action
       return Object.assign({}, state, { data })
     case GEO_CODE_ADDR:
-      const { addr } = action
-      return Object.assign({}, state, { addr })
+      const coordinates = action.addr[0]
+      return Object.assign({}, state, { coordinates })
     case META_DATA:
       return Object.assign({}, state, {
         geoFiles: fromJS(action.geoFiles),

--- a/test/actions/appActions.test.js
+++ b/test/actions/appActions.test.js
@@ -1,6 +1,8 @@
 /* eslint-env jest */
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
+import fetchMock from 'fetch-mock'
+import { Map } from 'immutable'
 
 import actions from 'actions'
 import { changeYear, pullMetaData } from 'actions/appActions'
@@ -18,10 +20,18 @@ describe('changeYear', () => {
 
 describe('pullMetaData', () => {
   it('fetches metadata file and triggers action', () => {
+    fetchMock.get('*', { geoFiles: { a: 'test' }, statsFiles: 'hi' })
     const store = mockStore({})
 
+    const expectedAction = {
+      type: actions.META_DATA,
+      geoFiles: Map({a: 'test'}),
+      statsFiles: 'hi',
+      branch: 'a'
+    }
+
     store.dispatch(pullMetaData()).then(() =>
-      expect(store.getActions()).toEqual([{ type: actions.META_DATA, geoFiles: 'testFiles' }])
+      expect(store.getActions()).toEqual([expectedAction])
     )
   })
 })

--- a/test/actions/appActions.test.js
+++ b/test/actions/appActions.test.js
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+
+import actions from 'actions'
+import { changeYear, pullMetaData } from 'actions/appActions'
+
+const mockStore = configureMockStore([thunk])
+
+describe('changeYear', () => {
+  it('dispatches a CHANGE_YEAR action', () => {
+    const store = mockStore({})
+
+    store.dispatch(changeYear('2015'))
+    expect(store.getActions()).toEqual([{ type: actions.CHANGE_YEAR, year: '2015' }])
+  })
+})
+
+describe('pullMetaData', () => {
+  it('fetches metadata file and triggers action', () => {
+    const store = mockStore({})
+
+    store.dispatch(pullMetaData()).then(() =>
+      expect(store.getActions()).toEqual([{ type: actions.META_DATA, geoFiles: 'testFiles' }])
+    )
+  })
+})

--- a/test/actions/appActions.test.js
+++ b/test/actions/appActions.test.js
@@ -11,7 +11,10 @@ const mockStore = configureMockStore([thunk])
 
 describe('changeYear', () => {
   it('dispatches a CHANGE_YEAR action', () => {
-    const store = mockStore({})
+    const store = mockStore({
+      mapDataReducer: { geoFiles: { size: 0 } },
+      mapControllerReducer: {}
+    })
 
     store.dispatch(changeYear('2015'))
     expect(store.getActions()).toEqual([{ type: actions.CHANGE_YEAR, year: '2015' }])
@@ -26,8 +29,7 @@ describe('pullMetaData', () => {
     const expectedAction = {
       type: actions.META_DATA,
       geoFiles: Map({a: 'test'}),
-      statsFiles: 'hi',
-      branch: 'a'
+      statsFiles: 'hi'
     }
 
     store.dispatch(pullMetaData()).then(() =>

--- a/test/actions/geoCodeAction.test.js
+++ b/test/actions/geoCodeAction.test.js
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import fetchMock from 'fetch-mock'
+
+import actions from 'actions'
+import { geoCodeAddress } from 'actions/geoCodeAction'
+
+const mockStore = configureMockStore([thunk])
+
+describe('geoCodeAddress', () => {
+  it('looks up coordinates from Google', () => {
+    const store = mockStore({})
+
+    fetchMock.get(
+      'begin:https://maps.googleapis.com/maps/api/geocode/json?address=testaddr',
+      { results: [{ geometry: { location: 'testcoords' } }] }
+    )
+
+    store.dispatch(geoCodeAddress('testaddr')).then(() =>
+      expect(store.getActions()).toEqual([{ type: actions.GEO_CODE_ADDR, addr: ['testcoords'] }])
+    )
+  })
+})

--- a/test/actions/mapActions.test.js
+++ b/test/actions/mapActions.test.js
@@ -5,7 +5,12 @@ import fetchMock from 'fetch-mock'
 import { Map } from 'immutable'
 
 import actions from 'actions'
-import { switchBranch, fetchGeoJson, setCurrentDistrict } from 'actions/mapActions'
+import {
+  switchBranch,
+  fetchGeoJson,
+  setCurrentDistrict,
+  fetchStatsJson
+} from 'actions/mapActions'
 
 const mockStore = configureMockStore([thunk])
 
@@ -54,5 +59,24 @@ describe('setCurrentDistrict', () => {
       type: actions.CHANGE_ACTIVE_DISTRICT,
       district: 'somedistrict'
     })
+  })
+})
+
+describe('fetchStatsJson', () => {
+  it('fetches stats and dispatches result', () => {
+    const store = mockStore({
+      mapDataReducer: { statsFiles: { lower: 'lowerstats' } },
+      mapControllerReducer: { branch: 'lower' }
+    })
+
+    fetchMock.get(
+      'end:lowerstats.json',
+      { some: 'statsjson' }
+    )
+
+    store.dispatch(fetchStatsJson()).then(() =>
+      expect(store.getActions())
+        .toEqual([{ type: actions.STATS_LOADED, stats: { some: 'statsjson' } }])
+    )
   })
 })

--- a/test/actions/mapActions.test.js
+++ b/test/actions/mapActions.test.js
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import fetchMock from 'fetch-mock'
+
+import actions from 'actions'
+import { switchBranch, setCurrentDistrict } from 'actions/mapActions'
+
+const mockStore = configureMockStore([thunk])
+
+describe('switchBranch', () => {
+  it('dispatches a switch layer action', () => {
+    const store = mockStore({ mapDataReducer: { statsFiles: [] }, mapControllerReducer: {} })
+
+    store.dispatch(switchBranch('federal'))
+
+    expect(store.getActions()).toEqual([{ type: actions.MAP_SWITCH_LAYER, year: null, branch: 'federal' }])
+  })
+})
+
+describe('setCurrentDistrict', () => {
+  it('retuns correct action with passed in district', () => {
+    const action = setCurrentDistrict('somedistrict')
+
+    expect(action).toEqual({
+      type: actions.CHANGE_ACTIVE_DISTRICT,
+      district: 'somedistrict'
+    })
+  })
+})

--- a/test/actions/mapActions.test.js
+++ b/test/actions/mapActions.test.js
@@ -2,19 +2,47 @@
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import fetchMock from 'fetch-mock'
+import { Map } from 'immutable'
 
 import actions from 'actions'
-import { switchBranch, setCurrentDistrict } from 'actions/mapActions'
+import { switchBranch, fetchGeoJson, setCurrentDistrict } from 'actions/mapActions'
 
 const mockStore = configureMockStore([thunk])
 
 describe('switchBranch', () => {
   it('dispatches a switch layer action', () => {
-    const store = mockStore({ mapDataReducer: { statsFiles: [] }, mapControllerReducer: {} })
+    const store = mockStore({
+      mapDataReducer: { statsFiles: [], geoFiles: Map({ federal: { 2015: 'somefile' } }) },
+      mapControllerReducer: { year: '2015', branch: 'federal' } }
+    )
+
+    fetchMock.get(
+      'end:somefile.geojson',
+      { some: 'geojson' }
+    )
 
     store.dispatch(switchBranch('federal'))
 
-    expect(store.getActions()).toEqual([{ type: actions.MAP_SWITCH_LAYER, year: null, branch: 'federal' }])
+    expect(store.getActions()).toEqual([{ type: actions.MAP_SWITCH_LAYER, year: '2015', branch: 'federal' }])
+  })
+})
+
+describe('fetchGeoJson', () => {
+  it('fetches district geojson layer and dispatches update', () => {
+    const store = mockStore({
+      mapDataReducer: { geoFiles: Map({ upper: { 2015: 'somefile' } }) },
+      mapControllerReducer: { branch: 'upper', year: '2015' }
+    })
+
+    fetchMock.get(
+      'end:somefile.geojson',
+      { some: 'geojson' }
+    )
+
+    store.dispatch(fetchGeoJson()).then(() =>
+      expect(store.getActions())
+        .toEqual([{ type: actions.GEO_DATA_LOADED, data: { some: 'geojson' } }])
+    )
   })
 })
 

--- a/test/components/SearchBar.test.js
+++ b/test/components/SearchBar.test.js
@@ -2,9 +2,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import SearchBar from '../../src/components/SearchBar'
+import { Provider } from 'react-redux'
+import store from '../../src/configureStore'
 
 it('renders without crashing', () => {
   const div = document.createElement('div')
-  const map = <SearchBar />
+  const map = <Provider store={store}><SearchBar /></Provider>
   ReactDOM.render(map, div)
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4470,13 +4470,7 @@ promise@7.1.1, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.0.0, prop-types@^15.5.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@~15.5.7:
-  version "15.5.8"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
-  dependencies:
-    fbjs "^0.8.9"
-
-prop-types@^15.5.9:
+prop-types@^15.0.0, prop-types@^15.5.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.9, prop-types@~15.5.7:
   version "15.5.9"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.9.tgz#d478eef0e761396942f70c78e772f76e8be747c9"
   dependencies:
@@ -4724,6 +4718,14 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-mock-store@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.2.3.tgz#1b3ad299da91cb41ba30d68e3b6f024475fb9e1b"
+
+redux-thunk@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
 
 redux@^3.6.0:
   version "3.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2198,6 +2198,14 @@ fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fetch-mock@^5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-5.12.0.tgz#7543d2c3fff8da86acc63fd4bcbf96de64dbebc2"
+  dependencies:
+    glob-to-regexp "^0.3.0"
+    node-fetch "^1.3.3"
+    path-to-regexp "^1.7.0"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -2440,6 +2448,10 @@ glob-parent@^2.0.0:
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
   dependencies:
     is-glob "^2.0.0"
+
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@~7.1.1:
   version "7.1.1"
@@ -3732,7 +3744,7 @@ node-emoji@^1.4.1:
   dependencies:
     string.prototype.codepointat "^0.2.0"
 
-node-fetch@^1.0.1:
+node-fetch@^1.0.1, node-fetch@^1.3.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
   dependencies:
@@ -4086,7 +4098,7 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-path-to-regexp@^1.5.3:
+path-to-regexp@^1.5.3, path-to-regexp@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1708,7 +1708,7 @@ domutils@1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-dotenv@^2.0.0:
+dotenv@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-2.0.0.tgz#bd759c357aaa70365e01c96b7b0bec08a6e0d949"
 
@@ -4475,6 +4475,13 @@ prop-types@^15.0.0, prop-types@^15.5.0, prop-types@^15.5.4, prop-types@^15.5.7, 
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
     fbjs "^0.8.9"
+
+prop-types@^15.5.9:
+  version "15.5.9"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.9.tgz#d478eef0e761396942f70c78e772f76e8be747c9"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 proxy-addr@~1.1.3:
   version "1.1.4"


### PR DESCRIPTION
Add rudimentary tests for all our action creators. This required moving the actual dispatches to the components and switching the asynchronous ones to use redux-thunk.